### PR TITLE
Use AlSarya branding logo on login, admin panel, and dashboard

### DIFF
--- a/resources/views/components/app-logo.blade.php
+++ b/resources/views/components/app-logo.blade.php
@@ -1,6 +1,4 @@
-<div class="flex aspect-square size-8 items-center justify-center rounded-md bg-accent-content text-accent-foreground">
-    <x-app-logo-icon class="size-5 fill-current text-white" />
-</div>
+<img src="{{ asset('images/alsarya-logo.png') }}" alt="{{ config('app.name', 'السارية') }}" class="h-8 w-auto" />
 <div class="ml-1 grid flex-1 text-left text-sm">
-    <span class="mb-0.5 truncate leading-none font-semibold">Laravel Starter Kit</span>
+    <span class="mb-0.5 truncate leading-none font-semibold">{{ config('app.name', 'السارية') }}</span>
 </div>

--- a/resources/views/filament/brand/logo.blade.php
+++ b/resources/views/filament/brand/logo.blade.php
@@ -1,11 +1,6 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 40" width="100" height="40">
-    <defs>
-        <linearGradient id="logoGradient" x1="0%" y1="0%" x2="100%" y2="0%">
-            <stop offset="0%" style="stop-color:#f59e0b;stop-opacity:1" />
-            <stop offset="100%" style="stop-color:#d97706;stop-opacity:1" />
-        </linearGradient>
-    </defs>
-    <text x="50%" y="25" text-anchor="middle" fill="url(#logoGradient)" font-family="Tajawal, sans-serif" font-size="20" font-weight="bold">
+<div class="flex items-center gap-2">
+    <img src="{{ asset('images/alsarya-logo.png') }}" alt="{{ config('app.name', 'السارية') }}" class="h-8 w-auto" />
+    <span class="text-lg font-bold" style="font-family: Tajawal, sans-serif; background: linear-gradient(90deg, #f59e0b, #d97706); -webkit-background-clip: text; -webkit-text-fill-color: transparent;">
         السارية
-    </text>
-</svg>
+    </span>
+</div>

--- a/resources/views/filament/pages/auth/login.blade.php
+++ b/resources/views/filament/pages/auth/login.blade.php
@@ -1,15 +1,7 @@
 <x-filament-panels::page.simple>
     <x-slot name="card">
         <div class="w-full flex justify-center mb-4">
-            @if (filled($logo = filament()->getLogoUrl()))
-                <img src="{{ $logo }}" alt="{{ config('app.name') }}" class="h-16">
-            @else
-                <div class="bg-primary-500 h-16 w-16 rounded-full flex items-center justify-center">
-                    <span class="text-white text-2xl font-bold">
-                        {{ strtoupper(substr(config('app.name'), 0, 1)) }}
-                    </span>
-                </div>
-            @endif
+            <img src="{{ asset('images/alsarya-logo.png') }}" alt="{{ config('app.name', 'السارية') }}" class="h-16 w-auto" />
         </div>
 
         <h2 class="text-center text-2xl font-bold tracking-tight text-gray-950">


### PR DESCRIPTION
- Dashboard header: Replace generic Laravel SVG icon with alsarya-logo.png and show the app name instead of "Laravel Starter Kit"
- Filament admin panel: Add alsarya-logo.png alongside the Arabic text gradient in the brand logo component
- Filament login page: Replace conditional logo/fallback circle with the branding logo image directly

https://claude.ai/code/session_012wszqs8afCGqoJKqXFKbdz